### PR TITLE
Update SFTPGo to v2.5.4 and set SFTPGO_SFTPD__KEX_ALGORITHMS and SFTPGO_SFTPD__HOST_KEY_ALGORITHMS env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ It will launch Redis, PostgreSQL, Tika, Gotenberg, SFTPGo and Paperless-ngx insi
 
 If you want to have a VM runs Paperless-ngx, check out my other project which can be used to run everything on [Fedora CoreOS](https://docs.fedoraproject.org/en-US/fedora-coreos/).
 
-https://github.com/quickvm/fcos-layer-paperless-ngx
+<https://github.com/quickvm/fcos-layer-paperless-ngx>
 
 ## Setup
+
 0. Ensure `jq` and `podman` packages are installed (ex `dnf install jq podman`)
 1. Clone this repository
 2. `cd ppngx`
 3. Edit `start.sh` and customize at least these variables:
-  ```
+
+  ```bash
   PAPERLESS_TIME_ZONE=America/Chicago
   PAPERLESS_OCR_LANGUAGE=eng
   SFTPGO_ADMIN_PASSWORD=supersecret
@@ -21,21 +23,28 @@ https://github.com/quickvm/fcos-layer-paperless-ngx
   PAPERLESS_SECRET_KEY=chamgemechamgemechamgemechamgemechamgemechamgemechamgemechamgeme
   POSTGRESQL_PASSWORD=paperlesschangeme
   ```
+
 4. Run `./start.sh`
-5. Wait a bit and make sure http://localhost:8000 is loading paperless.
+5. Wait a bit and make sure <http://localhost:8000> is loading paperless.
 6. Add a superuser to paperless-ngx with:
-  ```
+
+  ```bash
   podman exec -it paperless-webserver python manage.py createsuperuser
   ```
+
 7. If you are going to send documents via SFTP use the `scanner` and password set in `SFTPGO_PAPERLESS_PASSWORD`. Some scanners need the RSA Public key from SFTPGo. It is output by the script and written out to a file `${PWD}/sftp_rsa_host_key.pub`
 
 ### Updating
+
 The most straightforward methodology is to pull the latest image you care about and re-run start.sh. For example:
-  ```
+
+  ```bash
   podman pull ghcr.io/paperless-ngx/paperless-ngx:latest
   ./start.sh
   ```
+
 This will pull the latest image, and assuming your `PAPERLESS_VERSION` specified in start.sh is `latest`, will rebuild the pod with the latest versions.
+
 ### Autostart with systemd
 
 **Rootless Podman**
@@ -77,7 +86,6 @@ Note: If you make changes to `start.sh` after generating the systemd units you w
 1. `systemctl enable --user --now pod-paperless.service`
 
 Or you can edit the systemd unit files directly with your changes and run `systemctl daemon-reload --user` and then run `systemctl restart --user pod-paperless.service`.
-
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ If you want to have a VM runs Paperless-ngx, check out my other project which ca
   podman exec -it paperless-webserver python manage.py createsuperuser
   ```
 
-7. If you are going to send documents via SFTP use the `scanner` and password set in `SFTPGO_PAPERLESS_PASSWORD`. Some scanners need the RSA Public key from SFTPGo. It is output by the script and written out to a file `${PWD}/sftp_rsa_host_key.pub`
+7. If you are going to send documents via SFTP use the `scanner` and password set in `SFTPGO_PAPERLESS_PASSWORD`. Some scanners need the RSA Public key from SFTPGo. It is output by the script and written out to a file `${PWD}/sftp_rsa_host_key.pub`. Also, most scanners are using older versions of OpenSSH so you might need to adjust `SFTPGO_SFTPD__KEX_ALGORITHMS` and `SFTPGO_SFTPD__HOST_KEY_ALGORITHMS` to match the right key algorithms so they can connect as clients to SFTPGo. For example my [Brother ADS2800w](https://www.brother-usa.com/products/ads2800w) need the following set to work with the latest version of SFTPGo (v2.5.4).
+
+  ```bash
+  SFTPGO_SFTPD__KEX_ALGORITHMS=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
+  SFTPGO_SFTPD__HOST_KEY_ALGORITHMS=rsa-sha2-256,rsa-sha2-512,ecdsa-sha2-nistp256,ssh-ed25519,ssh-rsa
+  ```
 
 ### Updating
 

--- a/start.sh
+++ b/start.sh
@@ -9,12 +9,15 @@ PAPERLESS_VERSION=latest
 PAPERLESS_TIME_ZONE=America/Chicago
 PAPERLESS_OCR_LANGUAGE=eng
 
+SFTPGO_VERSION=v2.5.4
 SFTPGO_SFTP_PORT=2022
 SFTPGO_HTTP_PORT=8022
 SFTPGO_ADMIN_USER=sftpadmin
 SFTPGO_ADMIN_PASSWORD=supersecret
 SFTPGO_PAPERLESS_USER=scanner
 SFTPGO_PAPERLESS_PASSWORD=anothersupersecret
+SFTPGO_SFTPD_KEX_ALGORITHMS=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1
+SFTPGO_SFTPD_HOST_KEY_ALGORITHMS=rsa-sha2-256,rsa-sha2-512,ecdsa-sha2-nistp256,ssh-ed25519,ssh-rsa
 
 PAPERLESS_SECRET_KEY=chamgemechamgemechamgemechamgemechamgemechamgemechamgemechamgeme
 
@@ -105,11 +108,11 @@ podman create --replace --pod paperless \
   -e SFTPGO_DEFAULT_ADMIN_USERNAME=${SFTPGO_ADMIN_USER} \
   -e SFTPGO_DEFAULT_ADMIN_PASSWORD=${SFTPGO_ADMIN_PASSWORD} \
   -e SFTPGO_HTTPD__BINDINGS__0__PORT=${SFTPGO_HTTP_PORT} \
-  -e SFTPGO_SFTPD__KEX_ALGORITHMS=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1 \
-  -e SFTPGO_SFTPD__HOST_KEY_ALGORITHMS=rsa-sha2-256,rsa-sha2-512,ecdsa-sha2-nistp256,ssh-ed25519,ssh-rsa \
+  -e SFTPGO_SFTPD__KEX_ALGORITHMS=${SFTPGO_SFTPD_KEX_ALGORITHMS} \
+  -e SFTPGO_SFTPD__HOST_KEY_ALGORITHMS=${SFTPGO_SFTPD_HOST_KEY_ALGORITHMS} \
   -v paperless-sftpgo:/var/lib/sftpgo:Z \
   -v paperless-consume:/opt/paperless/consume:rw,z \
-  ghcr.io/drakkan/sftpgo:v2.5.4
+  ghcr.io/drakkan/sftpgo:${SFTPGO_VERSION}
 podman start paperless-sftpgo
 
 sleep 5

--- a/start.sh
+++ b/start.sh
@@ -105,9 +105,11 @@ podman create --replace --pod paperless \
   -e SFTPGO_DEFAULT_ADMIN_USERNAME=${SFTPGO_ADMIN_USER} \
   -e SFTPGO_DEFAULT_ADMIN_PASSWORD=${SFTPGO_ADMIN_PASSWORD} \
   -e SFTPGO_HTTPD__BINDINGS__0__PORT=${SFTPGO_HTTP_PORT} \
+  -e SFTPGO_SFTPD__KEX_ALGORITHMS=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1,diffie-hellman-group1-sha1 \
+  -e SFTPGO_SFTPD__HOST_KEY_ALGORITHMS=rsa-sha2-256,rsa-sha2-512,ecdsa-sha2-nistp256,ssh-ed25519,ssh-rsa \
   -v paperless-sftpgo:/var/lib/sftpgo:Z \
   -v paperless-consume:/opt/paperless/consume:rw,z \
-  ghcr.io/drakkan/sftpgo:v2
+  ghcr.io/drakkan/sftpgo:v2.5.4
 podman start paperless-sftpgo
 
 sleep 5


### PR DESCRIPTION
The latest version of SFTPGo (v2.5.4) disables older [host_key_algorithms](https://github.com/drakkan/sftpgo/blob/main/docs/full-configuration.md?plain=1#L141) and [kex_algorithms](https://github.com/drakkan/sftpgo/blob/main/docs/full-configuration.md?plain=1#L143) which breaks connectivity on scanners that have old OpenSSH. In order to support things better and keep SFTPGo up-to-date this PR adds env vars for these directives and sets a version on SFTPGo vs just pulling the `v2` tag. 