### PR TITLE
Add --infra-name to the podman pod 

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -33,6 +33,7 @@ POSTGRESQL_PASSWORD=paperlesschangeme
 
 echo "Creating Paperless Pod..."
 podman pod create --replace --name paperless \
+  --infra-name paperless-pod \
   -p ${PAPERLESS_PORT}:${PAPERLESS_PORT} \
   -p ${SFTPGO_SFTP_PORT}:${SFTPGO_SFTP_PORT} \
   -p ${SFTPGO_HTTP_PORT}:${SFTPGO_HTTP_PORT}


### PR DESCRIPTION
This will make it so it is easier to see the infra container in `podman ps -a`

```bash
$ podman ps -f pod=paperless
CONTAINER ID  IMAGE                                       COMMAND               CREATED         STATUS                   PORTS                                                                   NAMES
f4564e0612f9  localhost/podman-pause:4.9.0-1706090847                           20 minutes ago  Up 20 minutes            0.0.0.0:2022->2022/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8022->8022/tcp  paperless-pod
7c7b11b6b24c  docker.io/library/redis:6                   redis-server          20 minutes ago  Up 20 minutes            0.0.0.0:2022->2022/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8022->8022/tcp  paperless-redis
a5a79c1d68e5  docker.io/apache/tika:latest                                      20 minutes ago  Up 20 minutes            0.0.0.0:2022->2022/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8022->8022/tcp  paperless-tika
add67843277f  docker.io/gotenberg/gotenberg:7             gotenberg             20 minutes ago  Up 20 minutes            0.0.0.0:2022->2022/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8022->8022/tcp  paperless-gotenberg
d177490049b3  ghcr.io/paperless-ngx/paperless-ngx:latest  /usr/local/bin/pa...  20 minutes ago  Up 20 minutes (healthy)  0.0.0.0:2022->2022/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8022->8022/tcp  paperless-webserver
7a339d291037  ghcr.io/drakkan/sftpgo:v2                   sftpgo serve          20 minutes ago  Up 20 minutes            0.0.0.0:2022->2022/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8022->8022/tcp  paperless-sftpgo
1b30d701fb42  docker.io/library/postgres:13               postgres              20 minutes ago  Up 20 minutes            0.0.0.0:2022->2022/tcp, 0.0.0.0:8000->8000/tcp, 0.0.0.0:8022->8022/tcp  paperless-postgresql
```